### PR TITLE
Ensure query args are preserved when connecting

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -52,7 +52,7 @@ pub fn Client(
         pub fn handshake(
             self: *Self,
             allocator: mem.Allocator,
-            path: []const u8,
+            uri: std.Uri,
             request_headers: ?[]const [2][]const u8,
             response_headers: *std.StringHashMapUnmanaged([]const u8),
         ) !void {
@@ -61,7 +61,7 @@ pub fn Client(
             std.crypto.random.bytes(buf[0..16]);
             const key = std.base64.standard.Encoder.encode(&buf, buf[0..16]);
 
-            try self.sender.sendRequest(path, request_headers, key);
+            try self.sender.sendRequest(uri, request_headers, key);
             try self.receiver.receiveResponse(allocator, response_headers);
             errdefer self.receiver.freeHttpHeaders(allocator, response_headers);
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -30,7 +30,7 @@ pub const Connection = struct {
     pub fn init(
         allocator: mem.Allocator,
         underlying_stream: net.Stream,
-        path: []const u8,
+        uri: std.Uri,
         request_headers: ?[]const [2][]const u8,
     ) !Connection {
         var buffered_reader = BufferedReader{ .unbuffered_reader = underlying_stream.reader() };
@@ -53,7 +53,7 @@ pub const Connection = struct {
             .headers = .{},
         };
 
-        try self.ws_client.handshake(allocator, path, request_headers, &self.headers);
+        try self.ws_client.handshake(allocator, uri, request_headers, &self.headers);
         return self;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,7 +34,7 @@ pub fn connect(allocator: mem.Allocator, uri: std.Uri, request_headers: ?[]const
     };
     errdefer stream.close();
 
-    return Connection.init(allocator, stream, uri.path, request_headers);
+    return Connection.init(allocator, stream, uri, request_headers);
 }
 
 test "Simple connection to :8080" {


### PR DESCRIPTION
Presently, query arguments in the connection URI are dropped and go unused. This patch would ensure they are preserved in the connect message sent. I'm not sure if I've chosen the best possible way of doing this, I am still inexperienced with zig, and couldn't find a way to simultaneously use `Sender.put` to use the write buffer, while allowing very long paths/querys longer than a `MASK_BUFFER_SIZE` buffer. I feel like its possible to use the writer directly while still buffering somehow, so I'm only submitting this as a draft in case you aren't happy with this solution.