### PR TITLE
Update to 0.12.0-dev.2811+3cafb9655, fix uri path parsing, refactor headers to future std.http.Header, add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/nikneym/ws/blob/main/misc/logo.png" alt="ws" width="60%" height="30%" />
+  <img src="./misc/logo.png" alt="ws" width="60%" height="30%" />
 </p>
 
 ws
@@ -58,7 +58,7 @@ test "Simple connection to :8080" {
 Planned
 ===========
 - [ ] WebSocket server support
-- [ ] TLS support out of the box (tracks `std.crypto.tls.Client`)
+- [x] TLS support out of the box (tracks `std.crypto.tls.Client`)
 - [x] Request & response headers
 - [ ] WebSocket Compression support
 

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     _ = b.addModule("ws", .{
-        .source_file = .{ .path = "src/main.zig" },
+        .root_source_file = .{ .path = "src/main.zig" },
     });
 
     const test_compile = b.addTest(.{
@@ -13,7 +13,8 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const run_unit_tests = b.addRunArtifact(test_compile);
 
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&test_compile.step);
+    test_step.dependOn(&run_unit_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+	.name = "ws",
+	.version = "0.0.1",
+
+	.paths = .{
+		"src",
+		"build.zig",
+		"build.zig.zon",
+		"README.md"
+	}
+}

--- a/src/client.zig
+++ b/src/client.zig
@@ -15,8 +15,7 @@ pub fn client(
     writer: anytype,
     comptime read_buffer_size: usize,
     comptime write_buffer_size: usize,
-) Client(@TypeOf(reader), @TypeOf(writer), read_buffer_size, write_buffer_size)
-{
+) Client(@TypeOf(reader), @TypeOf(writer), read_buffer_size, write_buffer_size) {
     var mask: [4]u8 = undefined;
     std.crypto.random.bytes(&mask);
 
@@ -40,7 +39,6 @@ pub fn Client(
         receiver: Receiver(Reader, read_buffer_size),
         sender: Sender(Writer, write_buffer_size),
 
-        /// Deallocate response headers.
         pub fn deinit(
             self: Self,
             allocator: mem.Allocator,
@@ -53,7 +51,7 @@ pub fn Client(
             self: *Self,
             allocator: mem.Allocator,
             uri: std.Uri,
-            request_headers: ?[]const [2][]const u8,
+            extra_headers: []const common.HttpHeader,
             response_headers: *std.StringHashMapUnmanaged([]const u8),
         ) !void {
             // create a random Sec-WebSocket-Key
@@ -61,21 +59,26 @@ pub fn Client(
             std.crypto.random.bytes(buf[0..16]);
             const key = std.base64.standard.Encoder.encode(&buf, buf[0..16]);
 
-            try self.sender.sendRequest(uri, request_headers, key);
+            try self.sender.sendRequest(uri, extra_headers, key);
             try self.receiver.receiveResponse(allocator, response_headers);
             errdefer self.receiver.freeHttpHeaders(allocator, response_headers);
+
+            // var iter = response_headers.iterator();
+            // while (iter.next()) |kv| {
+            //     std.debug.print("{s}={s}\n", .{ kv.key_ptr.*, kv.value_ptr.* });
+            // }
 
             try checkWebSocketAcceptKey(response_headers.*, key);
         }
 
-        const WsAcceptKeyError = error{KeyControlFailed, AcceptKeyNotFound};
+        const WsAcceptKeyError = error{ KeyControlFailed, AcceptKeyNotFound };
 
         /// Controls the accept key received from the server
         fn checkWebSocketAcceptKey(
             headers: std.StringHashMapUnmanaged([]const u8),
             key: []const u8,
         ) WsAcceptKeyError!void {
-            if (headers.get("Sec-WebSocket-Accept")) |sec_websocket_accept| {
+            if (headers.get("sec-websocket-accept")) |sec_websocket_accept| {
                 const magic_string = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
                 var hash_buf: [20]u8 = undefined;
@@ -115,7 +118,7 @@ pub fn Client(
         }
 
         /// TODO: Add usage example
-        /// Send send continuation frames or streaming messages to the server.
+        /// Send continuation frames or streaming messages to the server.
         pub fn stream(self: *Self, opcode: Opcode, payload: ?[]const u8) !void {
             return self.sender.stream(opcode, payload);
         }

--- a/src/common.zig
+++ b/src/common.zig
@@ -1,7 +1,7 @@
 // maximum control frame length
 pub const MAX_CTL_FRAME_LENGTH = 125;
 
-pub const Opcode = enum (u4) {
+pub const Opcode = enum(u4) {
     continuation = 0x0,
     text = 0x1,
     binary = 0x2,
@@ -30,14 +30,12 @@ pub const Message = struct {
     data: []const u8,
     code: ?u16, // only used in close messages
 
-    pub const Error = error{FragmentedMessage, UnknownOpcode};
+    pub const Error = error{ FragmentedMessage, UnknownOpcode };
 
     /// Create a WebSocket message from given fields.
     pub fn from(opcode: Opcode, data: []const u8, code: ?u16) Message.Error!Message {
         switch (opcode) {
-            .text, .binary,
-            .ping, .pong,
-            .close => {},
+            .text, .binary, .ping, .pong, .close => {},
 
             .continuation => return error.FragmentedMessage,
             else => return error.UnknownOpcode,
@@ -45,4 +43,10 @@ pub const Message = struct {
 
         return Message{ .type = opcode, .data = data, .code = code };
     }
+};
+
+// Replace with std.http.Header after https://github.com/ziglang/zig/pull/18955
+pub const HttpHeader = struct {
+    name: []const u8,
+    value: []const u8,
 };

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1,12 +1,12 @@
 const std = @import("std");
+const Client = @import("client.zig").Client;
+const client = @import("client.zig").client;
+const common = @import("common.zig");
+const Stream = @import("./stream.zig");
+
 const net = std.net;
 const mem = std.mem;
 const io = std.io;
-
-const Client = @import("client.zig").Client;
-const client = @import("client.zig").client;
-
-const common = @import("common.zig");
 const Opcode = common.Opcode;
 const Message = common.Message;
 
@@ -16,25 +16,26 @@ const WRITE_BUFFER_SIZE: usize = 1024 * 4;
 /// This is the direct implementation of ws over regular net.Stream.
 /// The Connection object will always use the current Stream implementation of net namespace.
 pub const Connection = struct {
-    underlying_stream: net.Stream,
+    underlying_stream: Stream,
     ws_client: *WsClient,
     buffered_reader: BufferedReader,
     headers: std.StringHashMapUnmanaged([]const u8),
 
     /// general types
     const WsClient = Client(Reader, Writer, READ_BUFFER_SIZE, WRITE_BUFFER_SIZE);
-    const BufferedReader = io.BufferedReader(4096, net.Stream.Reader);
+    const BufferedReader = io.BufferedReader(4096, Stream.Reader);
     const Reader = BufferedReader.Reader;
-    const Writer = net.Stream.Writer;
+    const Writer = Stream.Writer;
 
     pub fn init(
         allocator: mem.Allocator,
-        underlying_stream: net.Stream,
+        underlying_stream: Stream,
         uri: std.Uri,
-        request_headers: ?[]const [2][]const u8,
+        extra_headers: []const common.HttpHeader,
     ) !Connection {
-        var buffered_reader = BufferedReader{ .unbuffered_reader = underlying_stream.reader() };
-        var writer = underlying_stream.writer();
+        var owned_stream = underlying_stream;
+        var buffered_reader = BufferedReader{ .unbuffered_reader = owned_stream.reader() };
+        const writer = owned_stream.writer();
 
         const ws_client = try allocator.create(WsClient);
         errdefer allocator.destroy(ws_client);
@@ -47,13 +48,13 @@ pub const Connection = struct {
         );
 
         var self = Connection{
-            .underlying_stream = underlying_stream,
+            .underlying_stream = owned_stream,
             .ws_client = ws_client,
             .buffered_reader = buffered_reader,
             .headers = .{},
         };
 
-        try self.ws_client.handshake(allocator, uri, request_headers, &self.headers);
+        try self.ws_client.handshake(allocator, uri, extra_headers, &self.headers);
         return self;
     }
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -25,8 +25,8 @@ pub const Connection = struct {
     const WsClient = Client(Reader, Writer);
     pub const Options = struct {
         extra_headers: []const common.HttpHeader = &.{},
-        read_buffer_size: usize = 4096 * 100,
-        write_buffer_size: usize = 4096 * 10,
+        read_buffer_size: usize = 1 << 16,
+        write_buffer_size: usize = 1 << 14,
     };
 
     pub fn init(

--- a/src/main.zig
+++ b/src/main.zig
@@ -29,7 +29,8 @@ pub const ConnectOptions = struct {
 };
 
 /// Open a new WebSocket connection.
-/// Allocator is used for DNS resolving of host and the storage of response headers.
+/// Allocator is used for DNS resolving of host and the storage of response headers and for
+/// read/write buffers.
 pub fn connect(allocator: mem.Allocator, uri: std.Uri, options: ConnectOptions) !Connection {
     if (uri.host == null) return error.MissingHost;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,8 +24,8 @@ pub const Address = union(enum) {
 };
 
 pub const ConnectOptions = struct {
-    extra_headers: []const common.HttpHeader = &.{},
     ca_bundle: ?std.crypto.Certificate.Bundle = null,
+    connection_options: Connection.Options = .{},
 };
 
 /// Open a new WebSocket connection.
@@ -60,13 +60,13 @@ pub fn connect(allocator: mem.Allocator, uri: std.Uri, options: ConnectOptions) 
 
     const stream = Stream{ .net_stream = net_stream, .tls_client = tls_client };
 
-    return Connection.init(allocator, stream, uri, options.extra_headers);
+    return Connection.init(allocator, stream, uri, options.connection_options);
 }
 
-test "plain connection to :8080" {
+test "wss://echo.websocket.org" {
     const allocator = std.testing.allocator;
 
-    var ws = try connect(allocator, try std.Uri.parse("ws://localhost:8080/asdf"), .{});
+    var ws = try connect(allocator, try std.Uri.parse("wss://echo.websocket.org"), .{});
     defer ws.deinit(allocator);
 
     while (true) {

--- a/src/receiver.zig
+++ b/src/receiver.zig
@@ -82,7 +82,7 @@ pub fn Receiver(comptime Reader: type, comptime capacity: usize) type {
                         '\n' => break,
 
                         else => {
-                            buf[i] = b;
+                            buf[i] = std.ascii.toLower(b);
                             if (i < buf.len) {
                                 i += 1;
                             } else {
@@ -173,14 +173,14 @@ pub fn Receiver(comptime Reader: type, comptime capacity: usize) type {
                     const len = try self.reader.readAll(self.header_buffer[2..4]);
                     if (len < 2) return error.EndOfStream;
 
-                    return mem.readIntBig(u16, self.header_buffer[2..4]);
+                    return mem.readInt(u16, self.header_buffer[2..4], .big);
                 },
 
                 127 => {
                     const len = try self.reader.readAll(self.header_buffer[2..]);
                     if (len < 8) return error.EndOfStream;
 
-                    return mem.readIntBig(u64, self.header_buffer[2..]);
+                    return mem.readInt(u64, self.header_buffer[2..], .big);
                 },
 
                 inline else => var_length,
@@ -214,17 +214,17 @@ pub fn Receiver(comptime Reader: type, comptime capacity: usize) type {
                 0 => Message.from(.close, buf, null),
 
                 2 => { // without reason but code
-                    const code = mem.readIntBig(u16, buf[0..2]);
+                    const code = mem.readInt(u16, buf[0..2], .big);
 
                     return Message.from(.close, buf, code);
                 },
 
                 else => { // with reason
-                    const code = mem.readIntBig(u16, buf[0..2]);
+                    const code = mem.readInt(u16, buf[0..2], .big);
                     const reason = buf[2..];
 
                     return Message.from(.close, reason, code);
-                }
+                },
             };
         }
 

--- a/src/receiver.zig
+++ b/src/receiver.zig
@@ -138,10 +138,6 @@ pub fn Receiver(comptime Reader: type) type {
             const len = try self.reader.readAll(buf);
             if (len < 2) return error.EndOfStream;
 
-            const is_masked = buf[1] & 0x80 != 0;
-            if (is_masked)
-                return error.MaskedMessageFromServer; // FIXME: should this be allowed?
-
             // get length from variable length
             const var_length: u7 = @truncate(buf[1] & 0x7F);
             const length = try self.getLength(var_length);

--- a/src/receiver.zig
+++ b/src/receiver.zig
@@ -11,12 +11,12 @@ const MAX_CTL_FRAME_LENGTH = common.MAX_CTL_FRAME_LENGTH;
 // server should not be sending masked messages.
 const MAX_HEADER_SIZE = 10;
 
-pub fn Receiver(comptime Reader: type, comptime capacity: usize) type {
+pub fn Receiver(comptime Reader: type) type {
     return struct {
         const Self = @This();
 
         reader: Reader,
-        buffer: [capacity]u8 = undefined,
+        buffer: []u8,
         header_buffer: [MAX_HEADER_SIZE]u8 = undefined,
         // specified for ping, pong and close frames.
         control_buffer: [MAX_CTL_FRAME_LENGTH]u8 = undefined,

--- a/src/sender.zig
+++ b/src/sender.zig
@@ -25,14 +25,13 @@ fn getUriFullPath(uri: std.Uri) ![]const u8 {
     return uri_buf[0..stream.pos];
 }
 
-pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
+pub fn Sender(comptime Writer: type) type {
     return struct {
         const Self = @This();
 
         writer: Writer,
         mask: [4]u8,
-        // for buffered writes
-        buffer: [capacity]u8 = undefined,
+        buffer: []u8,
         end: usize = 0,
 
         pub fn sendRequest(

--- a/src/sender.zig
+++ b/src/sender.zig
@@ -9,9 +9,20 @@ const MAX_CTL_FRAME_LENGTH = common.MAX_CTL_FRAME_LENGTH;
 const MASK_BUFFER_SIZE: usize = 1024;
 const DEFAULT_CLOSE_CODE: u16 = 1000;
 
+var uri_buf: [MASK_BUFFER_SIZE]u8 = undefined;
 fn getUriFullPath(uri: std.Uri) ![]const u8 {
-    var buf: [MASK_BUFFER_SIZE]u8 = undefined;
-    return try std.fmt.bufPrint(&buf, "{}", .{uri});
+    var stream = std.io.fixedBufferStream(&uri_buf);
+    const writer = stream.writer();
+    try uri.writeToStream(.{
+        .scheme = false,
+        .authentication = false,
+        .authority = false,
+        .path = true,
+        .query = true,
+        .fragment = false,
+        .raw = false,
+    }, writer);
+    return uri_buf[0..stream.pos];
 }
 
 pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
@@ -27,7 +38,7 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
         pub fn sendRequest(
             self: *Self,
             uri: std.Uri,
-            request_headers: ?[]const [2][]const u8,
+            headers: []const common.HttpHeader,
             sec_websocket_key: []const u8,
         ) !void {
             // push http request line
@@ -37,29 +48,34 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
 
             // push default headers
             const default_headers =
-                "Pragma: no-cache\r\n" ++
-                "Cache-Control: no-cache\r\n" ++
-                "Connection: Upgrade\r\n" ++
-                "Upgrade: websocket\r\n" ++
-                "Sec-WebSocket-Version: 13\r\n";
+                "pragma: no-cache\r\n" ++
+                "cache-control: no-cache\r\n" ++
+                "connection: Upgrade\r\n" ++
+                "upgrade: websocket\r\n" ++
+                "sec-websocket-version: 13\r\n";
             try self.put(default_headers);
 
             // push websocket key
-            try self.put("Sec-WebSocket-Key: ");
+            try self.put("sec-websocket-key: ");
             try self.put(sec_websocket_key);
             try self.put("\r\n");
 
-            // push user defined headers
-            if (request_headers) |headers| {
-                for (headers) |header| {
-                    try self.put(header[0]);
-                    try self.put(": ");
-                    try self.put(header[1]);
-                    try self.put("\r\n");
-                }
+            // push host
+            if (uri.host) |h| {
+                try self.put("host: ");
+                try self.put(h);
+                try self.put("\r\n");
             }
 
-            // send 'em all 
+            // push user defined headers
+            for (headers) |h| {
+                try self.put(h.name);
+                try self.put(": ");
+                try self.put(h.value);
+                try self.put("\r\n");
+            }
+
+            // send 'em all
             try self.put("\r\n");
             return self.flush();
         }
@@ -78,7 +94,7 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
                     return self.writer.writeAll(bytes);
             }
 
-            mem.copy(u8, self.buffer[self.end..], bytes);
+            mem.copyForwards(u8, self.buffer[self.end..], bytes);
             self.end += bytes.len;
         }
 
@@ -91,21 +107,21 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
             buf[1] = 0x80;
             if (header.len < 126) {
                 buf[1] |= @truncate(header.len);
-                mem.copy(u8, buf[2..], &self.mask);
+                mem.copyForwards(u8, buf[2..], &self.mask);
 
                 // 2 + 4
                 return self.put(buf[0..6]);
             } else if (header.len < 65536) {
                 buf[1] |= 126;
-                mem.writeIntBig(u16, buf[2..4], @as(u16, @truncate(header.len)));
-                mem.copy(u8, buf[4..], &self.mask);
+                mem.writeInt(u16, buf[2..4], @as(u16, @truncate(header.len)), .big);
+                mem.copyForwards(u8, buf[4..], &self.mask);
 
                 // 2 + 2 + 4
                 return self.put(buf[0..8]);
             } else {
                 buf[1] |= 127;
-                mem.writeIntBig(u64, buf[2..10], header.len);
-                mem.copy(u8, buf[10..], &self.mask);
+                mem.writeInt(u64, buf[2..10], header.len, .big);
+                mem.copyForwards(u8, buf[10..], &self.mask);
 
                 // 2 + 8 + 4
                 return self.put(&buf);
@@ -135,7 +151,7 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
 
             while (current_chunk < num_of_chunks) : (current_chunk += 1) {
                 pos = current_chunk * MASK_BUFFER_SIZE;
-                const chunk = data[pos..pos + MASK_BUFFER_SIZE];
+                const chunk = data[pos .. pos + MASK_BUFFER_SIZE];
 
                 self.maskBytes(buf[0..], chunk, pos);
                 try self.put(buf[0..]);
@@ -146,7 +162,7 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
 
             // got remainder
             pos += MASK_BUFFER_SIZE;
-            const chunk = data[pos..pos + remainder];
+            const chunk = data[pos .. pos + remainder];
 
             self.maskBytes(&buf, chunk, pos);
             return self.put(buf[0..remainder]);
@@ -225,15 +241,13 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
             try self.putHeader(.{
                 .len = 0,
                 .opcode = switch (opcode) {
-                    .text, .binary,
-                    .continuation => opcode,
+                    .text, .binary, .continuation => opcode,
                     .end => .continuation,
 
                     else => return error.UnknownOpcode,
                 },
                 .fin = switch (opcode) {
-                    .text, .binary,
-                    .continuation => false,
+                    .text, .binary, .continuation => false,
                     .end => true,
 
                     else => return error.UnknownOpcode,
@@ -256,38 +270,17 @@ pub fn Sender(comptime Writer: type, comptime capacity: usize) type {
     };
 }
 
-test "std.Uri processing results in expected paths" {
-    const uris = [_]std.Uri {
-        try std.Uri.parse("ws://localhost"),
-        try std.Uri.parse("ws://localhost/"),
-        try std.Uri.parse("ws://localhost?query=example"),
-        try std.Uri.parse("ws://localhost/?query=example"),
-        try std.Uri.parse("ws://localhost/?query1=&&something&query2=somethingelse"),
-        try std.Uri.parse("ws://localhost/?query1=something with spaces&query2=somethingelse"),
-        try std.Uri.parse("ws://localhost:8080"),
-        try std.Uri.parse("ws://localhost:8080/"),
-        try std.Uri.parse("ws://localhost:8080?query=example"),
-        try std.Uri.parse("ws://localhost:8080/?query=example"),
-        try std.Uri.parse("ws://localhost:8080/?query1=&&something&query2=somethingelse"),
-        try std.Uri.parse("ws://localhost:8080/?query1=something with spaces&query2=somethingelse"),
-    };
+fn expectPath(expected: []const u8, uri_string: []const u8) !void {
+    const uri = try std.Uri.parse(uri_string);
+    try std.testing.expectEqualStrings(expected, try getUriFullPath(uri));
+}
 
-    const paths = [_][]const u8{
-        "/",
-        "/",
-        "/?query=example",
-        "/?query=example",
-        "/?query1=&&something&query2=somethingelse",
-        "/?query1=something%20with%20spaces&query2=somethingelse",
-        "/",
-        "/",
-        "/?query=example",
-        "/?query=example",
-        "/?query1=&&something&query2=somethingelse",
-        "/?query1=something%20with%20spaces&query2=somethingelse",
-    };
-    
-    for (uris, paths) |uri, path| {
-        try std.testing.expectEqualSlices(u8, path, try getUriFullPath(uri));
-    }
+test "std.Uri processing results in expected paths" {
+    try expectPath("/", "ws://localhost");
+    try expectPath("/", "ws://localhost/");
+    try expectPath("/?query=example", "ws://localhost?query=example");
+    try expectPath("/?query=example", "ws://localhost/?query=example");
+    try expectPath("/?query1=&&something&query2=somethingelse", "ws://localhost/?query1=&&something&query2=somethingelse");
+    try expectPath("/?query1=something%20with%20spaces&query2=somethingelse", "ws://localhost/?query1=something with spaces&query2=somethingelse");
+    try expectPath("/?query1=something%20with%20spaces&query2=somethingelse", "ws://localhost/?query1=something with spaces&query2=somethingelse");
 }

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -1,0 +1,103 @@
+/// abstract tls behind reader and writer
+const std = @import("std");
+
+net_stream: std.net.Stream,
+tls_client: ?std.crypto.tls.Client,
+
+const Self = @This();
+const io = std.io;
+
+pub const ReadError = error{
+    SystemResources,
+    Unexpected,
+    WouldBlock,
+    ConnectionResetByPeer,
+    AccessDenied,
+    InputOutput,
+    OperationAborted,
+    BrokenPipe,
+    Overflow,
+    ConnectionTimedOut,
+    IsDir,
+    NotOpenForReading,
+    SocketNotConnected,
+    NetNameDeleted,
+    TlsAlertUnexpectedMessage,
+    TlsAlertBadRecordMac,
+    TlsAlertRecordOverflow,
+    TlsAlertHandshakeFailure,
+    TlsAlertBadCertificate,
+    TlsAlertUnsupportedCertificate,
+    TlsAlertCertificateRevoked,
+    TlsAlertCertificateExpired,
+    TlsAlertCertificateUnknown,
+    TlsAlertIllegalParameter,
+    TlsAlertUnknownCa,
+    TlsAlertAccessDenied,
+    TlsAlertDecodeError,
+    TlsAlertDecryptError,
+    TlsAlertProtocolVersion,
+    TlsAlertInsufficientSecurity,
+    TlsAlertInternalError,
+    TlsAlertInappropriateFallback,
+    TlsAlertMissingExtension,
+    TlsAlertUnsupportedExtension,
+    TlsAlertUnrecognizedName,
+    TlsAlertBadCertificateStatusResponse,
+    TlsAlertUnknownPskIdentity,
+    TlsAlertCertificateRequired,
+    TlsAlertNoApplicationProtocol,
+    TlsAlertUnknown,
+    TlsUnexpectedMessage,
+    TlsIllegalParameter,
+    TlsRecordOverflow,
+    TlsBadRecordMac,
+    TlsConnectionTruncated,
+    TlsDecodeError,
+    TlsBadLength,
+};
+pub const WriteError = error{
+    SystemResources,
+    Unexpected,
+    WouldBlock,
+    ConnectionResetByPeer,
+    AccessDenied,
+    FileTooBig,
+    NoSpaceLeft,
+    DeviceBusy,
+    InputOutput,
+    OperationAborted,
+    BrokenPipe,
+    DiskQuota,
+    InvalidArgument,
+    NotOpenForWriting,
+    LockViolation,
+};
+
+pub const Reader = io.Reader(*Self, ReadError, read);
+pub const Writer = io.Writer(*Self, WriteError, write);
+
+pub fn reader(self: *Self) Reader {
+    return .{ .context = self };
+}
+
+pub fn writer(self: *Self) Writer {
+    return .{ .context = self };
+}
+
+pub fn read(self: *Self, dest: []u8) ReadError!usize {
+    if (self.tls_client) |*t| return try t.read(self.net_stream, dest);
+
+    return try self.net_stream.read(dest);
+}
+
+pub fn write(self: *Self, bytes: []const u8) WriteError!usize {
+    if (self.tls_client) |*t| return try t.write(self.net_stream, bytes);
+
+    return try self.net_stream.write(bytes);
+}
+
+pub fn close(self: *Self) void {
+    if (self.tls_client) |*t| _ = t.writeEnd(self.net_stream, "", true) catch {};
+    self.net_stream.close();
+}


### PR DESCRIPTION
Not sure the status of this project, but I found it easier to hack at than the more mature https://github.com/karlseguin/websocket.zig . Here are various fixes I made to get it working for wss://socket.polygon.io/stocks

I also made unit tests run with `zig build test` and added `build.zig.zon` for package support.

Closes #1 .